### PR TITLE
Add support for global mixins, directives, filters & components in slots (fixes #105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ next
 ----
 
 - no longer expose component as 'fullcalendar' when used globally
+- global mixins, directives, filters & components work inside slots
 
 
 v5.2.0 (2020-07-30)

--- a/src/custom-content-type.ts
+++ b/src/custom-content-type.ts
@@ -51,11 +51,8 @@ function buildVDomHandler(parent: Vue) {
 function initVue(initialContent: VNode[], parent: Vue) {
   return new Vue({
     parent,
-    props: {
-      content: Array as PropType<VNode[]>
-    },
-    propsData: {
-      content: initialContent
+    data: {
+      content: initialContent,
     },
     render(h) {
       let { content } = this

--- a/src/custom-content-type.ts
+++ b/src/custom-content-type.ts
@@ -12,15 +12,16 @@ export function wrapVDomGenerator(vDomGenerator: NormalizedScopedSlot) {
   }
 }
 
+export function createVueContentTypePlugin(parent: Vue) {
+  return createPlugin({
+    contentTypeHandlers: {
+      vue: function() { return buildVDomHandler(parent); }, // looks for the `vue` key
+    }
+  });
+}
 
-export const VueContentTypePlugin = createPlugin({
-  contentTypeHandlers: {
-    vue: buildVDomHandler // looks for the `vue` key
-  }
-})
 
-
-function buildVDomHandler() {
+function buildVDomHandler(parent: Vue) {
   let currentEl: HTMLElement
   let v: ReturnType<typeof initVue> // the Vue instance
 
@@ -34,7 +35,7 @@ function buildVDomHandler() {
     }
 
     if (!v) {
-      v = initVue(vDomContent)
+      v = initVue(vDomContent, parent)
 
       // vue's mount method *replaces* the given element. create an artificial inner el
       let innerEl = document.createElement('span')
@@ -47,9 +48,9 @@ function buildVDomHandler() {
   }
 }
 
-
-function initVue(initialContent: VNode[]) {
+function initVue(initialContent: VNode[], parent: Vue) {
   return new Vue({
+    parent,
     props: {
       content: Array as PropType<VNode[]>
     },

--- a/tests/main.js
+++ b/tests/main.js
@@ -397,6 +397,35 @@ it('renders and rerenders a custom slot', async () => {
   expect(eventEl.findAll('b').length).toBe(1)
 })
 
+const COMPONENT_USING_ROOT_OPTIONS_IN_SLOT = {
+  components: {
+    FullCalendar,
+  },
+  template: `
+    <FullCalendar :options='calendarOptions'>
+      <template v-slot:eventContent="arg">this is an event</template>
+    </FullCalendar>
+  `,
+  data() {
+    return {
+      calendarOptions: {
+        ...DEFAULT_OPTIONS,
+        events: buildEvents(1)
+      }
+    }
+  },
+}
+
+/**
+ * Ensures we can use plugins and emit events from within the slots just
+ * like any other place.
+ */
+it('adds slots as child components.', async () => {
+  let wrapper = mount(COMPONENT_USING_ROOT_OPTIONS_IN_SLOT)
+
+  expect(wrapper.findComponent(FullCalendar).vm.$children.length).toBe(1);
+});
+
 
 // FullCalendar options utils
 


### PR DESCRIPTION
This PR fixes #105 

Previously it was not possible to use global mixins, directives, filters or components inside FullCalendar's named slots. This is now possible by passing the root Vue options onto each Vue instance created per slot.

For example, using i18n was not possible before, but should be working fine now.

```
Vue.use(VueI18n);
const app = new Vue({
  i18n: new VueI18n(),
  el: '#app',
});

Vue.component('Event', {
  template: '<span>{{ $t("hello") }}</span>'
});

<div id="app">
  <FullCalendar>
    <template v-slot:eventContent="arg">
      <Event />
    </template>
  </FullCalendar>
</div>
```